### PR TITLE
Talk: Add state change for talk

### DIFF
--- a/internal/gamestate/gamestate.go
+++ b/internal/gamestate/gamestate.go
@@ -8,11 +8,20 @@ import (
 	"github.com/kemcbride/gin-quest/internal/room"
 )
 
+type State int // Kind of like "mode" for the UI/potential actions
+
+const (
+    StateExplore State = iota
+    StateTalk
+    StateMenu
+    StateBattle
+)
+
 type GameSave struct {
 	X       int    `json:"x"`
 	Y       int    `json:"y"`
 	RoomKey string `json:"roomkey"`
-	State   int    `json:"state"`
+	State   State  `json:"state"`
 }
 
 type GameState struct {
@@ -70,6 +79,9 @@ func (gs *GameState) GetStatusBlurb() string {
 }
 
 func (gs *GameState) CanMove(dx int, dy int) bool {
+	if gs.Save.State != StateExplore {
+		return false
+	}
 	// For now, we just want to check if it's water or mountain
 	// Or, the edge of the map.
 	// Eventually could handle a case where we fly or swim.
@@ -120,15 +132,25 @@ func (gs *GameState) Portal(server embed.FS) error {
 			return nil // return without modifying game state, eg. going thru portal
 		}
 		// Update GameState to be in new room at destloc from portal
+		gs.Save.State = StateExplore
 		gs.Save.RoomKey = portal.Map
-		fmt.Println(portal.Map)
 		gs.Save.X = portal.DestLoc.X
 		gs.Save.Y = portal.DestLoc.Y
 		gs.Room = gs.GetCurrRoom()
-		fmt.Println(gs.GetCurrRoomName())
 		gs.Room.LoadMap(server)
 		gs.Room.LoadMeta(server)
 	}
+	return nil
+}
+
+func (gs *GameState) Talk(server embed.FS) error {
+	_, found := gs.Room.GetNpc(gs.Save.X, gs.Save.Y)
+	if !found {
+		return nil // return without modifying game state, eg. going thru portal
+	}
+	// Update GameState to be in new room at destloc from portal
+	gs.Save.State = StateTalk
+	// This breaks everything LOL and also how do we know that it's happening??
 	return nil
 }
 
@@ -151,6 +173,11 @@ func (gs *GameState) GetCurrRoom() room.Room {
 
 func (gs *GameState) GetCurrRoomName() string {
 	return gs.GetRoomHash()[gs.Save.RoomKey].Name
+}
+
+func (gs *GameState) GetCurrRoomDescription() string {
+	// TODO: Have this use the description fields from meta.json
+	return fmt.Sprintf("You're somewhere in %s.", gs.Room.Name)
 }
 
 func (gs *GameState) GetMapRange(coord int, size int) []int {

--- a/internal/room/room.go
+++ b/internal/room/room.go
@@ -195,7 +195,3 @@ func (r *Room) GetPortalNameHere(x int, y int) string {
 	}
 	return ""
 }
-
-func (r *Room) GetDescriptionHere(x int, y int) string {
-	return "You're somewhere alright."
-}

--- a/main.go
+++ b/main.go
@@ -61,20 +61,30 @@ func Game(c *gin.Context) {
 	gs.Room.LoadMap(server)
 	gs.Room.LoadMeta(server)
 
-	// if the query involved a portal, try that before other motion:
-	if _, portal := c.GetQuery("portal"); portal {
-		_ = gs.Portal(server)
+
+	if _, talk := c.GetQuery("talk"); talk {
+		_ = gs.Talk(server)
+	} else if _, move := c.GetQuery("move"); move { // If doing talk, don't do other motion actions
+		gs.Save.State = gamestate.StateExplore
 	}
-	// Let's check the query path and respond to up, down, left, right.
-	if _, up := c.GetQuery("up"); up {
-		gs.MoveUp()
-	} else if _, down := c.GetQuery("down"); down {
-		gs.MoveDown()
-	}
-	if _, left := c.GetQuery("left"); left {
-		gs.MoveLeft()
-	} else if _, right := c.GetQuery("right"); right {
-		gs.MoveRight()
+
+	if gs.Save.State == gamestate.StateExplore {
+		// Handle Explore-based query options
+		// if the query involved a portal, try that before other motion:
+		if _, portal := c.GetQuery("portal"); portal {
+			_ = gs.Portal(server)
+		}
+		// Let's check the query path and respond to up, down, left, right.
+		if _, up := c.GetQuery("up"); up {
+			gs.MoveUp()
+		} else if _, down := c.GetQuery("down"); down {
+			gs.MoveDown()
+		}
+		if _, left := c.GetQuery("left"); left {
+			gs.MoveLeft()
+		} else if _, right := c.GetQuery("right"); right {
+			gs.MoveRight()
+		}
 	}
 
 	// Save the game state back
@@ -85,10 +95,8 @@ func Game(c *gin.Context) {
 	}
 	c.SetCookie("game", string(j), cookieAge, "/", domain, false, true)
 
-	c.HTML(http.StatusOK, "googoogaga", gin.H{
+	c.HTML(http.StatusOK, "game", gin.H{
 		"title":  "Game Page",
-		"x":      gs.Save.X,
-		"y":      gs.Save.Y,
 		"room":   gs.GetCurrRoom(),
 		"gs":     &gs,
 		"xrange": gs.GetMapRange(gs.Save.X, 3),
@@ -171,6 +179,15 @@ func main() {
 func createMyRender() multitemplate.Renderer {
 	r := multitemplate.NewRenderer()
 	r.AddFromFiles("index", "./templates/layouts/index.html")
-	r.AddFromFiles("googoogaga", "./templates/layouts/game.html", "templates/includes/map.html", "templates/includes/menu.html")
+	r.AddFromFiles(
+		"game",
+		"./templates/layouts/game.html",
+		"templates/includes/map.html",
+		"templates/includes/menu.html",
+		"templates/includes/status.html",
+		"templates/includes/conversation.html",
+		"templates/includes/misc.html", // Resolves to top-level Menus (items, skills)
+		"templates/includes/battle.html",
+	)
 	return r
 }

--- a/static/main.css
+++ b/static/main.css
@@ -31,9 +31,13 @@ body {
 }
 
 .status {
-    padding: 10%;
     text-align: center;
     vertical-align: middle;
+    padding-bottom: 2vh;
+}
+
+.conversation {
+    margin: auto;
 }
 
 .menu {

--- a/templates/includes/battle.html
+++ b/templates/includes/battle.html
@@ -1,0 +1,4 @@
+{{ define "battle" }}
+<div class="battle">
+</div>
+{{ end }}

--- a/templates/includes/conversation.html
+++ b/templates/includes/conversation.html
@@ -1,0 +1,20 @@
+{{ define "conversation" }}
+
+<div class="conversation">
+	<div class="character">
+		<img src="./static/img/ginquestprotag-kougra0.1.png"></img>
+		{{ if .gs.Room.NpcHere .gs.Save.X .gs.Save.Y }}
+			<img src="./static/img/{{ .gs.GetGridLocImg .gs.Save.X .gs.Save.Y }}"></img>
+		{{ end }}
+	</div>
+	<div class="description">
+		</br>
+		{{ if .gs.Room.NpcHere .gs.Save.X .gs.Save.Y }}
+			{{ $npcname := .gs.Room.GetNpcNameHere .gs.Save.X .gs.Save.Y }}
+			You're talking with {{ $npcname }}.
+		{{ end }}
+		</br>
+		<a href=".?move">Return to map?</a>
+	</div>
+</div>
+{{ end }}

--- a/templates/includes/menu.html
+++ b/templates/includes/menu.html
@@ -11,14 +11,13 @@
 		{{ end }}
 	</div>
 	<div class="description">
-		{{- .gs.Room.GetDescriptionHere $xr $yr -}}
 		</br>
 		{{ if .gs.Room.NpcHere $xr $yr }}
 			{{ $npcname := .gs.Room.GetNpcNameHere $xr $yr }}
-			You see {{ $npcname }} milling around here. Go and <a href=".?talk">talk to them?</a>
+			You see {{ $npcname }} milling around here. <a href=".?talk">Talk?</a>
 		{{ else if .gs.Room.PortalHere $xr $yr }}
 			{{ $portalname := .gs.Room.GetPortalNameHere $xr $yr }}
-			You see the entrance to {{ $portalname }} here. <a href=".?portal">Go?</a>
+			You see {{ $portalname }} here. <a href=".?portal">Go?</a>
 		{{ end }}
 	</div>
 	<div class="controls">
@@ -47,9 +46,6 @@
 		<div class="dir" onclick="window.location.href='.?down&right';">
 			↘
 		</div>
-	</div>
-	<div class="status">
-		{{ .gs.GetStatusBlurb }}
 	</div>
 </div>
 {{ end }}

--- a/templates/includes/misc.html
+++ b/templates/includes/misc.html
@@ -1,0 +1,4 @@
+{{ define "misc" }}
+<div class="misc">
+</div>
+{{ end }}

--- a/templates/includes/status.html
+++ b/templates/includes/status.html
@@ -1,0 +1,8 @@
+{{ define "status" }}
+<div class="status">
+	<h2>GinQuest</h2>
+	Name: ProtagonistKougra -~-~- Level: 1 -~-~- {{ .gs.GetStatusBlurb }}
+	</br>
+	{{- .gs.GetCurrRoomDescription -}}
+</div>
+{{ end }}

--- a/templates/layouts/game.html
+++ b/templates/layouts/game.html
@@ -6,15 +6,19 @@
 	</head>
 
 	<body>
-		<h2> {{ .gs.GetCurrRoomName }} </h2>
+		{{ template "status" . }}
 
-		{{ $xs := .xrange }}
-		{{ $ys := .yrange }}
-		{{ $gs := .gs }}
 		<div class="container">
-			{{ template "map" . }}
-
-			{{ template "menu" . }}
+			{{ if (eq .gs.Save.State 0) }}
+				{{ template "map" . }}
+				{{ template "menu" . }}
+			{{ else if (eq .gs.Save.State 1) }}
+				{{ template "conversation" . }}
+			{{ else if (eq .gs.Save.State 2) }}
+				{{ template "misc" . }}
+			{{ else if (eq .gs.Save.State 3) }}
+				{{ template "battle" . }}
+			{{ end }}
 		</div>
 
 


### PR DESCRIPTION
Doesn't actually contain a convo for Recurtum nor the conversation flow logic, but does do:

* state chnage between `Explore` (default) and `Talk` (new one)
* some moved around status description stuff for better flow + better matching OG NQ ( #42 )
* templates for talk as well as the other states

I'm calling the state `Conversation` and the action `Talk`.


Even though this doesn't have conversation flow, I think this counts as "interactable location" for the purposes of #8 

eg.

closes #42
closes #8