### PR TITLE
menu: naive mostly hardcoded options menu (next step = enable new game)

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,10 @@ func Game(c *gin.Context) {
 	gs.Room.LoadMap(server)
 	gs.Room.LoadMeta(server)
 
+	if _, menu := c.GetQuery("menu"); menu {
+		gs.Save.State = gamestate.StateMenu
+	}
+
 	if _, talk := c.GetQuery("talk"); talk {
 		_ = gs.Talk(server)
 	} else if _, move := c.GetQuery("move"); move { // If doing talk, don't do other motion actions

--- a/templates/includes/misc.html
+++ b/templates/includes/misc.html
@@ -1,4 +1,11 @@
 {{ define "misc" }}
 <div class="misc">
+	<ul>
+		<li>You have beaten NORMAL mode N times.</li>
+		<li>You have beaten Evil! mode e times.</li>
+		<li>You have beaten INSANE!! mode 0 times.</li>
+	</ul>
+	</br>
+	<a href=".?move">Return to map?</a>
 </div>
 {{ end }}

--- a/templates/includes/status.html
+++ b/templates/includes/status.html
@@ -3,6 +3,12 @@
 	<h2>GinQuest</h2>
 	Name: ProtagonistKougra -~-~- Level: 1 -~-~- {{ .gs.GetStatusBlurb }}
 	</br>
+	<a href=".?menu">Options</a> |
+	<a href=".?skills">Skills</a> |
+	<a href=".?items">Items</a> |
+	Difficulty: Normal |
+	Experience: [~~~|-----]
+	</br>
 	{{- .gs.GetCurrRoomDescription -}}
 </div>
 {{ end }}


### PR DESCRIPTION
Lets you flip between menu/settings & normal explore mode.

No actual functionality like reset/actual records / save/load though.

Tweaks the status bar to havemore of the links too, so I can just fill those out.