### PR TITLE
combat/stats: initial stab (no change, but level now part of GSave)

### DIFF
--- a/internal/combat/combat.go
+++ b/internal/combat/combat.go
@@ -1,0 +1,51 @@
+package combat
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type CombatStats struct {
+	Level     int
+	HealthMax int
+	Strength  int
+	Defence   int
+	Avoid     int
+	HitRate   int
+}
+
+type EnemyData struct {
+	Enemies []CombatStats
+}
+
+// Load enemies, nto direct combat stats...
+func (ed *EnemyData) ToJson() ([]byte, error) {
+	j, err := json.Marshal(ed)
+	if err != nil {
+		return []byte{}, err
+	}
+	return j, nil
+}
+
+func FromJson(b []byte) (*EnemyData, error) {
+	ed := &EnemyData{}
+	err := json.Unmarshal(b, &ed)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling enemy data: %v, %s", err, b)
+	}
+	return ed, nil
+}
+
+func DeriveCombatStats(level int) (CombatStats, error) {
+	if level <= 0 {
+		return CombatStats{}, fmt.Errorf("invalid level <= 0 : %d", level)
+	}
+	return CombatStats{
+		Level:     level,
+		HealthMax: level + 10,
+		Strength:  level,
+		Defence:   level,
+		Avoid:     level,
+		HitRate:   level,
+	}, nil
+}

--- a/internal/gamestate/gamestate.go
+++ b/internal/gamestate/gamestate.go
@@ -22,6 +22,7 @@ type GameSave struct {
 	Y       int    `json:"y"`
 	RoomKey string `json:"roomkey"`
 	State   State  `json:"state"`
+	Level   int    `json:"level"`
 }
 
 type GameState struct {
@@ -43,6 +44,10 @@ func GameSaveFromJson(b []byte) (*GameSave, error) {
 	err := json.Unmarshal(b, &gs)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling gamesave: %v, %s", err, b)
+	}
+
+	if gs.Level <= 0 {
+		return nil, fmt.Errorf("error loading gamesave from json: level cannot be <= 0, %d", gs.Level)
 	}
 	return gs, nil
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func Game(c *gin.Context) {
 			Y:       0,
 			RoomKey: "mh04i224",
 			State:   0,
+			Level:   1,
 		}
 
 		// Initiialize a fresh game

--- a/static/enemies.json
+++ b/static/enemies.json
@@ -1,0 +1,12 @@
+{
+	"enemies": {
+		"Recurtum": {
+			"level": 100,
+			"healthmax": 100,
+			"strength": 0,
+			"defence": 1,
+			"avoid": 0,
+			"hitrate": 0
+		}
+	}
+}


### PR DESCRIPTION
Adds level to GameSave + it's serialized to always 1 in main.go

Adds combat/combat.go and some basic stats with the notion that we'll just derive stats from:
* level
* skills
* equipment
* (theoretically conditions during battle)

Anyways, what this does is add:
* enemies.json with a placeholder for recurtum (my intended demo training battle)
* some default "deriveCombatStats" + json serislization for enemyData
* level to be part of the GameSave


Intended to contribute to:
#28 #32 #34 and #9 and probably #11  a bit too.