### PR TITLE
Km/several naive skills

### DIFF
--- a/internal/gamestate/gamestate.go
+++ b/internal/gamestate/gamestate.go
@@ -21,13 +21,13 @@ const (
 )
 
 type GameSave struct {
-	X       int    `json:"x"`
-	Y       int    `json:"y"`
-	RoomKey string `json:"roomkey"`
-	State   State  `json:"state"`
-	Level   int    `json:"level"`
-	Name    string `json:"name"`
-	// SkillLevels [string]int `json:"skilllevels"` // how do maps work???
+	X           int            `json:"x"`
+	Y           int            `json:"y"`
+	RoomKey     string         `json:"roomkey"`
+	State       State          `json:"state"`
+	Level       int            `json:"level"`
+	Name        string         `json:"name"`
+	SkillLevels map[string]int `json:"skilllevels"`
 }
 
 type GameState struct {
@@ -55,6 +55,10 @@ func GameSaveFromJson(b []byte) (*GameSave, error) {
 		return nil, fmt.Errorf("error loading gamesave from json: level cannot be <= 0, %d", gs.Level)
 	}
 	return gs, nil
+}
+
+func NewSkillLevels() map[string]int {
+	return skills.NewSkillLevels()
 }
 
 func (gs *GameState) ToJson() ([]byte, error) {
@@ -226,6 +230,26 @@ func (gs *GameState) PortalHere(x int, y int) bool {
 	return gs.Room.PortalHere(x, y)
 }
 
-func (gs *GameState) GetStrengthSkill() skills.Skill {
-	return skills.StrengthSkill
+func (gs *GameState) GetSkills() map[string]skills.Skill {
+	return skills.Skills
+}
+
+func (save *GameSave) GetSkillLevels() map[string]int {
+	return save.SkillLevels
+}
+
+func (save *GameSave) GetUnusedSkillPoints() int {
+	// Let's say every 5 levels (incl. level 1) you get 3 points
+	// and each level you get one otherwise
+	// so if you're level 15, you have 3 + 3 + 3 + 3 (1, 5, 10, 15)
+	// plus one for each other level (2, 3, 4, 6, 7, 8, 9, 11, 12, 13, 14)
+	// aka: 3x(lvl/5 +1) + (lvl - (lvl/5 - 1))
+	landmarkPoints := 3 * (save.Level/5 + 1)
+	normalPoints := save.Level - max((save.Level/5-1), 0) - 1
+	earnedPoints := landmarkPoints + normalPoints
+	usedPoints := 0
+	for _, skillLevel := range save.SkillLevels {
+		usedPoints += skillLevel
+	}
+	return max(earnedPoints-usedPoints, 0)
 }

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -2,7 +2,6 @@ package skills
 
 import ()
 
-
 // Note - the struct OUGHT to have something to do with
 // how the skill actually works but we can cross that bridge when we get to it.
 type Skill struct {
@@ -18,14 +17,46 @@ type SkillLevel struct {
 }
 
 var StrengthSkill = Skill{
-	Name: "Strength",
-	Description: "This skill makes you stronger",
-	Cap: 9999,
+	Name:        "Strength",
+	Description: "makes you stronger",
+	Cap:         9999,
+}
+
+var Skills = map[string]Skill{
+	"Vitality": Skill{
+		Name:        "Vitality",
+		Description: "raises your max health",
+		Cap:         100,
+	},
+	"Strength": StrengthSkill,
+	"Defence": Skill{
+		Name:        "Defence",
+		Description: "raises your defence",
+		Cap:         100,
+	},
+	"Dodge": Skill{
+		Name:        "Dodge",
+		Description: "raises your avoidance",
+		Cap:         100,
+	},
+	"Accuracy": Skill{
+		Name:        "Accuracy",
+		Description: "raises your hit rate",
+		Cap:         100,
+	},
 }
 
 var StrengthLevel = SkillLevel{
 	Level: 5,
-	name: "Strength",
+	name:  "Strength",
+}
+
+func NewSkillLevels() map[string]int {
+	m := make(map[string]int)
+	for name := range Skills {
+		m[name] = 0
+	}
+	return m
 }
 
 func (s *Skill) GetName() string {

--- a/main.go
+++ b/main.go
@@ -104,12 +104,13 @@ func handleNewGameSubmission(c *gin.Context) {
 	name := c.DefaultPostForm("name", "ProtagonistKougra")
 	// Update cookie data
 	gsave := &gamestate.GameSave{
-		X:       0,
-		Y:       0,
-		RoomKey: "mh04i224",
-		State:   0,
-		Level:   1,
-		Name:    name,
+		X:           0,
+		Y:           0,
+		RoomKey:     "mh04i224",
+		State:       0,
+		Level:       1,
+		Name:        name,
+		SkillLevels: gamestate.NewSkillLevels(),
 	}
 
 	// Initiialize a fresh game

--- a/templates/includes/inventory.html
+++ b/templates/includes/inventory.html
@@ -1,6 +1,6 @@
 {{ define "inventory" }}
 <div class="inventory">
-	INVENTORY MENU
+	<h3>INVENTORY</h3>
 	</br>
 	<a href=".?move">Return to map?</a>
 </div>

--- a/templates/includes/options.html
+++ b/templates/includes/options.html
@@ -1,5 +1,7 @@
 {{ define "options" }}
 <div class="options">
+	<h3> OPTIONS </h3>
+	</br>
 	<ul>
 		<li>You have beaten <b>NORMAL</b> mode N times.</li>
 		<li>You have beaten <span style="color: red;">Evil!</span> mode e times.</li>

--- a/templates/includes/skills.html
+++ b/templates/includes/skills.html
@@ -1,24 +1,36 @@
 {{ define "skills" }}
 
-{{ $skill := .gs.GetStrengthSkill }}
+{{ $saveSkillLevels := .gs.Save.GetSkillLevels }}
+{{ $unusedPoints := .gs.Save.GetUnusedSkillPoints }}
 <div class="skills">
-	SKILLS MENU
+	<h3> SKILLS </h3>
 	</br>
+
+	{{ if gt $unusedPoints 0 }}
+	{{ if gt $unusedPoints 1 }}
+	<span style="color:red"><b>* * *  YOU HAVE {{ $unusedPoints }} UNSPENT SKILL POINTS * * *</b></span>
+	{{ else }}
+	<span style="color:red"><b>* * *  YOU HAVE {{ $unusedPoints }} UNSPENT SKILL POINT * * *</b></span>
+	{{ end }}
+	</br>
+	</br>
+	{{ end }}
 	<table>
 		<tr>
-			<b>
-				<td> SKILL NAME </td>
-				<td> SKILL LEVEL </td>
-				<td> SKILL CAP </td>
-				<td> SKILL DESCRIPTION </td>
-			</b>
+			<td><b> NAME </b></td>
+			<td><b> LEVEL </b></td>
+			<td><b> MAX LEVEL </b></td>
+			<td><b> DESCRIPTION </b></td>
 		</tr>
+{{ range $name, $skill := .gs.GetSkills }}
+{{ $skilllevel := index $saveSkillLevels $name }}
 		<tr>
 			<td> {{ $skill.Name }} </td>
-			<td> 0 </td>
+			<td> {{ $skilllevel }} </td>
 			<td> {{ $skill.Cap }} </td>
 			<td> {{ $skill.Description }} </td>
 		</tr>
+{{ end }}
 	</table>
 	</br>
 	<a href=".?move">Return to map?</a>

--- a/templates/includes/status.html
+++ b/templates/includes/status.html
@@ -8,7 +8,5 @@
 	<a href=".?inventory">inventory</a> |
 	Difficulty: Normal |
 	Experience: [~~~|-----]
-	</br>
-	{{- .gs.GetCurrRoomDescription -}}
 </div>
 {{ end }}

--- a/templates/includes/status.html
+++ b/templates/includes/status.html
@@ -1,11 +1,16 @@
 {{ define "status" }}
+{{ $unusedPoints := .gs.Save.GetUnusedSkillPoints }}
 <div class="status">
 	<h2>GinQuest</h2>
 	Name: <b>{{ .gs.GetName }}</b> -~-~- Level: <b>{{ .gs.GetLevel }}</b> -~-~- {{ .gs.GetStatusBlurb }}
 	</br>
 	<a href=".?options">Options</a> |
+	{{ if gt $unusedPoints 0 }}
+	<b><a href=".?skills">Skills</a></b>|
+	{{ else }}
 	<a href=".?skills">Skills</a> |
-	<a href=".?inventory">inventory</a> |
+	{{ end }}
+	<a href=".?inventory">Inventory</a> |
 	Difficulty: Normal |
 	Experience: [~~~|-----]
 </div>


### PR DESCRIPTION
* style headers on options, skills, inventory
* fix lowercase i in inventory in status template
* unspent skill logic (math might be wrong but w/e)
* added more skills into a map (they dont do anything yet)
* added skilllevels to game save
* bold style to skills on main status template if unspent points (not ideal but OK)


big contribution towards #28  and #34 
but there's still more to go (actual level up logic)
(actual skill behavior in combat, too)